### PR TITLE
Prefer the `hostvars[server].hostname` attribute in zoo.cfg, and default to just `server` if `.hostname` is not available.

### DIFF
--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -5,5 +5,5 @@ clientPort={{ client_port }}
 initLimit={{ init_limit }}
 syncLimit={{ sync_limit }}
 {% for server in zookeeper_hosts %}
-server.{{ hostvars[server].zoo_id }}={{server}}:2888:3888
+server.{{ hostvars[server].zoo_id }}={{ hostvars[server].hostname | default(server)}}:2888:3888
 {% endfor %}


### PR DESCRIPTION
This PR allows a `hostname` to be specified in the ansible hosts file, and then this value will be used in zookeeper's `zoo.cfg`.  This is a backwards-compatible change, meaning that if no hostname is specified, it will use the default `{{server}}` value just like before.

example hosts file:

```ini
[tag_Name_mesos_primary1a:vars]
zoo_id=1
hostname=mesos-primary1a

[tag_Name_mesos_primary2a:vars]
zoo_id=2
hostname=mesos-primary2a

[tag_Name_mesos_primary3a:vars]
zoo_id=3
hostname=mesos-primary3a
```